### PR TITLE
feat: add DIA-NN 2.5.0 container

### DIFF
--- a/.github/workflows/quantms-containers.yml
+++ b/.github/workflows/quantms-containers.yml
@@ -43,6 +43,7 @@ jobs:
         if: github.event_name == 'push' || github.event_name == 'pull_request'
         with:
           filters: |
+            diann_2_5_0:  [ 'diann-2.5.0/**', '.github/workflows/**' ]
             diann_2_3_2:  [ 'diann-2.3.2/**', '.github/workflows/**' ]
             diann_2_2_0:  [ 'diann-2.2.0/**', '.github/workflows/**' ]
             diann_2_1_0:  [ 'diann-2.1.0/**', '.github/workflows/**' ]
@@ -55,6 +56,7 @@ jobs:
         id: set-matrix
         env:
           EVENT: ${{ github.event_name }}
+          CHG_250: ${{ steps.filter.outputs.diann_2_5_0 }}
           CHG_232: ${{ steps.filter.outputs.diann_2_3_2 }}
           CHG_220: ${{ steps.filter.outputs.diann_2_2_0 }}
           CHG_210: ${{ steps.filter.outputs.diann_2_1_0 }}
@@ -64,7 +66,8 @@ jobs:
           CHG_RLK: ${{ steps.filter.outputs.relink_1_0_0 }}
         run: |
           DIANN_ALL='[
-            {"context":"diann-2.3.2","tag":"ghcr.io/bigbio/diann:2.3.2","sif":"diann-sif:2.3.2","extra_tags":"ghcr.io/bigbio/diann:latest","chg":"CHG_232"},
+            {"context":"diann-2.5.0","tag":"ghcr.io/bigbio/diann:2.5.0","sif":"diann-sif:2.5.0","extra_tags":"ghcr.io/bigbio/diann:latest","chg":"CHG_250"},
+            {"context":"diann-2.3.2","tag":"ghcr.io/bigbio/diann:2.3.2","sif":"diann-sif:2.3.2","extra_tags":"","chg":"CHG_232"},
             {"context":"diann-2.2.0","tag":"ghcr.io/bigbio/diann:2.2.0","sif":"diann-sif:2.2.0","extra_tags":"","chg":"CHG_220"},
             {"context":"diann-2.1.0","tag":"ghcr.io/bigbio/diann:2.1.0","sif":"diann-sif:2.1.0","extra_tags":"","chg":"CHG_210"},
             {"context":"diann-2.0.2","tag":"ghcr.io/bigbio/diann:2.0.2","sif":"diann-sif:2.0.2","extra_tags":"","chg":"CHG_20"},
@@ -79,9 +82,10 @@ jobs:
             DIANN=$(echo "$DIANN_ALL" | jq -c '[.[] | del(.chg)]')
             RELINK=$(echo "$RELINK_ALL" | jq -c '[.[] | del(.chg)]')
           else
-            DIANN=$(echo "$DIANN_ALL" | jq -c --arg c232 "${CHG_232:-false}" --arg c220 "${CHG_220:-false}" --arg c210 "${CHG_210:-false}" \
+            DIANN=$(echo "$DIANN_ALL" | jq -c --arg c250 "${CHG_250:-false}" --arg c232 "${CHG_232:-false}" --arg c220 "${CHG_220:-false}" --arg c210 "${CHG_210:-false}" \
               --arg c20 "${CHG_20:-false}" --arg c192 "${CHG_192:-false}" --arg c181 "${CHG_181:-false}" \
               '[.[] | select(
+                (.chg == "CHG_250" and $c250 == "true") or
                 (.chg == "CHG_232" and $c232 == "true") or
                 (.chg == "CHG_220" and $c220 == "true") or
                 (.chg == "CHG_210" and $c210 == "true") or

--- a/diann-2.5.0/Dockerfile
+++ b/diann-2.5.0/Dockerfile
@@ -1,0 +1,52 @@
+FROM ubuntu:22.04
+
+# Some metadata
+LABEL base_image="ubuntu:22.04"
+LABEL version="2"
+LABEL software="diann"
+LABEL software.version="2.5.0"
+LABEL about.summary="DIA-NN - a universal software for data-independent acquisition (DIA) proteomics data processing."
+LABEL about.home="https://github.com/vdemichev/DiaNN"
+LABEL about.documentation="https://github.com/vdemichev/DiaNN"
+LABEL about.license_file="https://github.com/vdemichev/DiaNN/LICENSE.txt"
+LABEL about.tags="Proteomics"
+LABEL maintainer="Yasset Perez-Riverol <ypriverol@gmail.com>"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update package lists and ensure package versions are up to date, Install necessary packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
+    unzip \
+    libgomp1 \
+    locales && \
+    rm -rf /var/lib/apt/lists/*
+
+# Configure locale to avoid runtime errors
+RUN locale-gen en_US.UTF-8 && \
+    update-locale LANG=en_US.UTF-8
+
+# Set environment variables for locale
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+
+# Download and install DIA-NN
+RUN wget --no-check-certificate https://github.com/vdemichev/DiaNN/releases/download/2.0/DIA-NN-2.5.0-Academia-Linux.zip && \
+    unzip DIA-NN-2.5.0-Academia-Linux.zip -d /usr/ && \
+    rm DIA-NN-2.5.0-Academia-Linux.zip
+
+# Remove unnecessary packages
+RUN apt-get remove -y wget unzip && apt-get autoremove -y && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set appropriate permissions for the DIA-NN folder
+RUN chmod +x /usr/diann-2.5.0/diann-linux
+
+# Create a symbolic link and add to PATH
+RUN ln -s /usr/diann-2.5.0/diann-linux /usr/diann-2.5.0/diann
+ENV PATH="$PATH:/usr/diann-2.5.0"
+
+WORKDIR /data/
+
+# NOTE: It is entirely the user's responsibility to ensure compliance with DIA-NN license terms.


### PR DESCRIPTION
## Summary
- Add DIA-NN 2.5.0 Academia Linux container (`diann-2.5.0/Dockerfile`)
- 2.5.0 becomes the `:latest` tag (replaces 2.3.2)
- CI workflow updated with change detection + build matrix entry

## DIA-NN 2.5.0 highlights
- Up to 70% increase in protein IDs for low sample amounts
- New deep learning model selection flags (`--rt-model`, `--fr-model`, `--im-model`, `--tokens`)
- New `--aa-eq` flag for amino acid equivalence in reannotation
- `--parent` flag to override model directory path

Container verified locally: `docker buildx build --platform linux/amd64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added DIA-NN version 2.5.0 support with Ubuntu 22.04-based container image.

* **Chores**
  * Updated container build configuration and workflow matrix selection logic.
  * Adjusted versioning tags for existing DIA-NN releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->