### PR TITLE
dotnet added to DIANN after 2.0.0 versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,9 @@ cython_debug/
 
 #Ignore cursor AI rules
 .cursor/rules/codacy.mdc
+
+# Local-only helper script for building Docker + Singularity images
+build-diann-singularity.sh
+
+# Local Singularity/Apptainer image cache produced by build-diann-singularity.sh
+singularity-cache/

--- a/README.md
+++ b/README.md
@@ -24,13 +24,25 @@ These containerized versions offer:
 
 **Important**: Due to licensing restrictions, DIA-NN containers are not publicly distributed. Users must build these containers locally or have access to the private `ghcr.io/bigbio/diann` registry.
 
-| Version | Directory      | Key Features                           | Container Tag                |
-| ------- | -------------- | -------------------------------------- | ---------------------------- |
-| 1.8.1   | `diann-1.8.1/` | Core DIA-NN, library-free analysis     | `ghcr.io/bigbio/diann:1.8.1` |
-| 1.9.2   | `diann-1.9.2/` | QuantUMS quantification, redesigned NN | `ghcr.io/bigbio/diann:1.9.2` |
-| 2.0.2   | `diann-2.0/`   | Parquet output, proteoform confidence  | `ghcr.io/bigbio/diann:2.0.2` |
-| 2.1.0   | `diann-2.1.0/` | Native .raw on Linux                   | `ghcr.io/bigbio/diann:2.1.0` |
-| 2.2.0   | `diann-2.2.0/` | Latest release                         | `ghcr.io/bigbio/diann:2.2.0` |
+| Version | Directory      | Key Features                                  | Container Tag                |
+| ------- | -------------- | --------------------------------------------- | ---------------------------- |
+| 1.8.1   | `diann-1.8.1/` | Core DIA-NN, library-free analysis            | `ghcr.io/bigbio/diann:1.8.1` |
+| 1.9.2   | `diann-1.9.2/` | QuantUMS quantification, redesigned NN        | `ghcr.io/bigbio/diann:1.9.2` |
+| 2.0.2   | `diann-2.0.2/` | Parquet output, proteoform confidence         | `ghcr.io/bigbio/diann:2.0.2` |
+| 2.1.0   | `diann-2.1.0/` | Native `.raw` on Linux (bundles .NET SDK 8)   | `ghcr.io/bigbio/diann:2.1.0` |
+| 2.2.0   | `diann-2.2.0/` | Native `.raw` on Linux (bundles .NET SDK 8)   | `ghcr.io/bigbio/diann:2.2.0` |
+| 2.3.2   | `diann-2.3.2/` | Native `.raw` on Linux (bundles .NET SDK 8)   | `ghcr.io/bigbio/diann:2.3.2` |
+| 2.5.0   | `diann-2.5.0/` | Native `.raw` on Linux (bundles .NET SDK 8)   | `ghcr.io/bigbio/diann:2.5.0` |
+
+> **Native Thermo `.raw` support (DIA-NN ≥ 2.1.0).** Starting with 2.1.0, DIA-NN
+> can read Thermo `.raw` files directly on Linux via bundled `RawWrapper.dll` /
+> `ThermoFisher.CommonCore.*` libraries (targeting `net8.0`). At startup
+> DIA-NN runs `dotnet --list-sdks` and, if no SDK is found, aborts with
+> `ERROR: cannot read .raw files, please download and install .NET Runtime
+> 8.0.14 or later`. The 2.1.0 / 2.2.0 / 2.3.2 / 2.5.0 images therefore install
+> `dotnet-sdk-8.0` (from Ubuntu 22.04 `jammy-updates`); no extra action is
+> needed. DIA-NN ≤ 2.0.2 does **not** ship the Thermo reader on Linux and
+> still requires external conversion (e.g. ThermoRawFileParser → `.mzML`).
 
 ```bash
 # Build Docker container locally
@@ -99,8 +111,10 @@ Please note the following license restrictions:
 ### DIA-NN Containers
 
 - Base Image: `ubuntu:22.04`
-- Available Versions: 1.8.1, 1.9.2, 2.0.2, 2.1.0, 2.2.0
+- Available Versions: 1.8.1, 1.9.2, 2.0.2, 2.1.0, 2.2.0, 2.3.2, 2.5.0
 - Architecture: `amd64`/`x86_64`
+- .NET SDK 8 (`dotnet-sdk-8.0`) is installed in 2.1.0+ images to enable
+  native Thermo `.raw` reading.
 
 ### Relink Container
 

--- a/diann-2.1.0/Dockerfile
+++ b/diann-2.1.0/Dockerfile
@@ -14,12 +14,18 @@ LABEL maintainer="Yasset Perez-Riverol <ypriverol@gmail.com>"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Update package lists and ensure package versions are up to date, Install necessary packages
+# Update package lists and ensure package versions are up to date, Install necessary packages.
+# dotnet-sdk-8.0 is required for DIA-NN >= 2.1.0 to read Thermo .raw natively on Linux.
+# DIA-NN ships Thermo DLLs targeting net8.0 and probes the environment via
+# `dotnet --list-sdks` at startup; a runtime-only install is NOT sufficient and
+# triggers: "cannot read .raw files, please download and install .NET Runtime 8.0.14 or later".
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     unzip \
     libgomp1 \
-    locales && \
+    locales \
+    ca-certificates \
+    dotnet-sdk-8.0 && \
     rm -rf /var/lib/apt/lists/*
 
 # Configure locale to avoid runtime errors
@@ -32,7 +38,7 @@ ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
 # Download and install DIA-NN
-RUN wget --no-check-certificate https://github.com/vdemichev/DiaNN/releases/download/2.0/DIA-NN-2.1.0-Academia-Linux.zip && \
+RUN wget https://github.com/vdemichev/DiaNN/releases/download/2.0/DIA-NN-2.1.0-Academia-Linux.zip && \
     unzip DIA-NN-2.1.0-Academia-Linux.zip -d /usr/ && \
     rm DIA-NN-2.1.0-Academia-Linux.zip
 

--- a/diann-2.2.0/Dockerfile
+++ b/diann-2.2.0/Dockerfile
@@ -13,11 +13,15 @@ LABEL maintainer="Yasset Perez-Riverol <ypriverol@gmail.com>"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# dotnet-sdk-8.0 is required for DIA-NN >= 2.1.0 to read Thermo .raw natively on Linux
+# (DIA-NN bundles Thermo DLLs targeting net8.0 and invokes `dotnet --list-sdks` at startup).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     unzip \
     libgomp1 \
-    locales && \
+    locales \
+    ca-certificates \
+    dotnet-sdk-8.0 && \
     rm -rf /var/lib/apt/lists/*
 
 RUN locale-gen en_US.UTF-8 && \
@@ -29,7 +33,7 @@ ENV LC_ALL=en_US.UTF-8
 
 # Download DIA-NN 2.2.0 (release tag: 2.0)
 # Zip contains diann-2.2.0/ at top level, so extract to /usr/
-RUN wget --no-check-certificate https://github.com/vdemichev/DiaNN/releases/download/2.0/DIA-NN-2.2.0-Academia-Linux.zip && \
+RUN wget https://github.com/vdemichev/DiaNN/releases/download/2.0/DIA-NN-2.2.0-Academia-Linux.zip && \
     unzip DIA-NN-2.2.0-Academia-Linux.zip -d /usr/ && \
     rm DIA-NN-2.2.0-Academia-Linux.zip
 

--- a/diann-2.3.2/Dockerfile
+++ b/diann-2.3.2/Dockerfile
@@ -14,12 +14,16 @@ LABEL maintainer="Yasset Perez-Riverol <ypriverol@gmail.com>"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Update package lists and ensure package versions are up to date, Install necessary packages
+# Update package lists and ensure package versions are up to date, Install necessary packages.
+# dotnet-sdk-8.0 is required for DIA-NN >= 2.1.0 to read Thermo .raw natively on Linux
+# (DIA-NN bundles Thermo DLLs targeting net8.0 and invokes `dotnet --list-sdks` at startup).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     unzip \
     libgomp1 \
-    locales && \
+    locales \
+    ca-certificates \
+    dotnet-sdk-8.0 && \
     rm -rf /var/lib/apt/lists/*
 
 # Configure locale to avoid runtime errors
@@ -32,7 +36,7 @@ ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
 # Download and install DIA-NN
-RUN wget --no-check-certificate https://github.com/vdemichev/DiaNN/releases/download/2.0/DIA-NN-2.3.2-Academia-Linux.zip && \
+RUN wget https://github.com/vdemichev/DiaNN/releases/download/2.0/DIA-NN-2.3.2-Academia-Linux.zip && \
     unzip DIA-NN-2.3.2-Academia-Linux.zip -d /usr/ && \
     rm DIA-NN-2.3.2-Academia-Linux.zip
 

--- a/diann-2.5.0/Dockerfile
+++ b/diann-2.5.0/Dockerfile
@@ -14,12 +14,16 @@ LABEL maintainer="Yasset Perez-Riverol <ypriverol@gmail.com>"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Update package lists and ensure package versions are up to date, Install necessary packages
+# Update package lists and ensure package versions are up to date, Install necessary packages.
+# dotnet-sdk-8.0 is required for DIA-NN >= 2.1.0 to read Thermo .raw natively on Linux
+# (DIA-NN bundles Thermo DLLs targeting net8.0 and invokes `dotnet --list-sdks` at startup).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     unzip \
     libgomp1 \
-    locales && \
+    locales \
+    ca-certificates \
+    dotnet-sdk-8.0 && \
     rm -rf /var/lib/apt/lists/*
 
 # Configure locale to avoid runtime errors
@@ -32,7 +36,7 @@ ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
 # Download and install DIA-NN
-RUN wget --no-check-certificate https://github.com/vdemichev/DiaNN/releases/download/2.0/DIA-NN-2.5.0-Academia-Linux.zip && \
+RUN wget https://github.com/vdemichev/DiaNN/releases/download/2.0/DIA-NN-2.5.0-Academia-Linux.zip && \
     unzip DIA-NN-2.5.0-Academia-Linux.zip -d /usr/ && \
     rm DIA-NN-2.5.0-Academia-Linux.zip
 


### PR DESCRIPTION
This pull request adds support for new DIA-NN container versions (2.3.2 and 2.5.0) and ensures that all containers for DIA-NN ≥ 2.1.0 install the required .NET SDK 8.0 to enable native Thermo `.raw` file reading on Linux. The documentation is updated to clearly describe these changes and the new requirements for native Thermo file support.

**Container build updates:**

* Added installation of `dotnet-sdk-8.0` and `ca-certificates` in the `Dockerfile` for all containers with DIA-NN ≥ 2.1.0 (`diann-2.1.0`, `diann-2.2.0`, `diann-2.3.2`, `diann-2.5.0`), ensuring native Thermo `.raw` file reading works out of the box. [[1]](diffhunk://#diff-71bdae59094c8179c2bc63bdc0a9329cd6b7c228aceb680136596cf72728b63bL17-R28) [[2]](diffhunk://#diff-7af033aefb4604129796cd5db864b8262de387c5d8a1f9606fc6cdc74c8609aaR16-R24) [[3]](diffhunk://#diff-1e580f0973dea2aa94f556ed6c97afa45b548cb0e647bc499f66b78bb1b0b775L17-R26) [[4]](diffhunk://#diff-225fb084b8844a7bca025473bdf9444d93267ec82746aacf0933565f885e63d7L17-R26)
* Removed the `--no-check-certificate` flag from `wget` commands in all relevant `Dockerfile`s, as `ca-certificates` are now installed and certificate checks are expected to succeed. [[1]](diffhunk://#diff-71bdae59094c8179c2bc63bdc0a9329cd6b7c228aceb680136596cf72728b63bL35-R41) [[2]](diffhunk://#diff-7af033aefb4604129796cd5db864b8262de387c5d8a1f9606fc6cdc74c8609aaL32-R36) [[3]](diffhunk://#diff-1e580f0973dea2aa94f556ed6c97afa45b548cb0e647bc499f66b78bb1b0b775L35-R39) [[4]](diffhunk://#diff-225fb084b8844a7bca025473bdf9444d93267ec82746aacf0933565f885e63d7L35-R39)

**Documentation updates:**

* Updated the `README.md` to list new available versions (2.3.2 and 2.5.0) and clarify that all containers from 2.1.0 onward bundle the .NET SDK 8 and support native Thermo `.raw` reading. Also added a detailed explanation of the .NET SDK requirement and the behavior of DIA-NN when the SDK is missing. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R45) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L102-R117)

These changes make it easier for users to work with Thermo `.raw` files directly in Linux containers and ensure the documentation accurately reflects the new capabilities and requirements.