### PR TITLE
feat: add wiffconverter container with `convert` CLI

### DIFF
--- a/.github/workflows/quantms-containers.yml
+++ b/.github/workflows/quantms-containers.yml
@@ -9,6 +9,7 @@ on:
       - "diann-*/Dockerfile"
       - "diann-*/**"
       - "relink-*/Dockerfile"
+      - "wiffconverter-*/**"
       - ".github/workflows/**"
   release:
     types: [published]
@@ -35,8 +36,10 @@ jobs:
     outputs:
       diann_matrix: ${{ steps.set-matrix.outputs.diann_matrix }}
       relink_matrix: ${{ steps.set-matrix.outputs.relink_matrix }}
+      wiffconverter_matrix: ${{ steps.set-matrix.outputs.wiffconverter_matrix }}
       has_diann: ${{ steps.set-matrix.outputs.has_diann }}
       has_relink: ${{ steps.set-matrix.outputs.has_relink }}
+      has_wiffconverter: ${{ steps.set-matrix.outputs.has_wiffconverter }}
     steps:
       - uses: actions/checkout@v4
 
@@ -53,6 +56,7 @@ jobs:
             diann_1_9_2:  [ 'diann-1.9.2/**', '.github/workflows/**' ]
             diann_1_8_1:  [ 'diann-1.8.1/**', '.github/workflows/**' ]
             relink_1_0_0: [ 'relink-1.0.0/**', '.github/workflows/**' ]
+            wiffconverter_0_10: [ 'wiffconverter-0.10/**', '.github/workflows/**' ]
 
       - name: Build matrices
         id: set-matrix
@@ -66,6 +70,7 @@ jobs:
           CHG_192: ${{ steps.filter.outputs.diann_1_9_2 }}
           CHG_181: ${{ steps.filter.outputs.diann_1_8_1 }}
           CHG_RLK: ${{ steps.filter.outputs.relink_1_0_0 }}
+          CHG_WC010: ${{ steps.filter.outputs.wiffconverter_0_10 }}
         run: |
           DIANN_ALL='[
             {"context":"diann-2.5.0","tag":"ghcr.io/bigbio/diann:2.5.0","sif":"diann-sif:2.5.0","extra_tags":"ghcr.io/bigbio/diann:latest","chg":"CHG_250"},
@@ -79,10 +84,14 @@ jobs:
           RELINK_ALL='[
             {"context":"relink-1.0.0","tag":"ghcr.io/${{ github.repository_owner }}/relink:1.0.0","sif":"relink-sif:1.0.0","extra_tags":"ghcr.io/${{ github.repository_owner }}/relink:latest","chg":"CHG_RLK"}
           ]'
+          WIFFCONV_ALL='[
+            {"context":"wiffconverter-0.10","tag":"ghcr.io/${{ github.repository_owner }}/wiffconverter:0.10","sif":"wiffconverter-sif:0.10","extra_tags":"ghcr.io/${{ github.repository_owner }}/wiffconverter:latest","chg":"CHG_WC010"}
+          ]'
 
           if [[ "$EVENT" == "release" || "$EVENT" == "workflow_dispatch" ]]; then
             DIANN=$(echo "$DIANN_ALL" | jq -c '[.[] | del(.chg)]')
             RELINK=$(echo "$RELINK_ALL" | jq -c '[.[] | del(.chg)]')
+            WIFFCONV=$(echo "$WIFFCONV_ALL" | jq -c '[.[] | del(.chg)]')
           else
             DIANN=$(echo "$DIANN_ALL" | jq -c --arg c250 "${CHG_250:-false}" --arg c232 "${CHG_232:-false}" --arg c220 "${CHG_220:-false}" --arg c210 "${CHG_210:-false}" \
               --arg c20 "${CHG_20:-false}" --arg c192 "${CHG_192:-false}" --arg c181 "${CHG_181:-false}" \
@@ -97,14 +106,19 @@ jobs:
               ) | del(.chg)]')
             RELINK=$(echo "$RELINK_ALL" | jq -c --arg crlk "${CHG_RLK:-false}" \
               '[.[] | select(.chg == "CHG_RLK" and $crlk == "true") | del(.chg)]')
+            WIFFCONV=$(echo "$WIFFCONV_ALL" | jq -c --arg cwc010 "${CHG_WC010:-false}" \
+              '[.[] | select(.chg == "CHG_WC010" and $cwc010 == "true") | del(.chg)]')
           fi
 
           echo "diann_matrix={\"include\":$DIANN}" >> $GITHUB_OUTPUT
           echo "relink_matrix={\"include\":$RELINK}" >> $GITHUB_OUTPUT
+          echo "wiffconverter_matrix={\"include\":$WIFFCONV}" >> $GITHUB_OUTPUT
           echo "has_diann=$([ "$DIANN" != "[]" ] && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "has_relink=$([ "$RELINK" != "[]" ] && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "has_wiffconverter=$([ "$WIFFCONV" != "[]" ] && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "DIA-NN: $DIANN"
           echo "Relink: $RELINK"
+          echo "WiffConverter: $WIFFCONV"
 
   # ── Build DIA-NN containers (sequential) ───────────────────────────────
   build-diann:
@@ -247,10 +261,68 @@ jobs:
             singularity push image.sif oras://ghcr.io/${{ github.repository_owner }}/$SIF_LATEST
           fi
 
+  # ── Build WiffConverter container (after Relink) ───────────────────────
+  build-wiffconverter:
+    name: "WiffConverter ${{ matrix.context }}"
+    needs: [detect-changes, build-diann, build-relink]
+    if: always() && needs.detect-changes.outputs.has_wiffconverter == 'true' && github.repository_owner == 'bigbio'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJSON(needs.detect-changes.outputs.wiffconverter_matrix) }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry (GHCR)
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./${{ matrix.context }}
+          push: ${{ github.event_name != 'pull_request' }}
+          load: true
+          tags: |
+            ${{ matrix.tag }}
+            ${{ matrix.extra_tags }}
+          cache-from: type=gha,scope=${{ matrix.context }}
+          cache-to: type=gha,scope=${{ matrix.context }},mode=max
+          provenance: false
+
+      - name: Set up Singularity
+        if: github.event_name != 'pull_request'
+        uses: eWaterCycle/setup-singularity@v7
+        with:
+          singularity-version: 3.8.7
+
+      - name: Convert to Singularity and push
+        if: github.event_name != 'pull_request'
+        run: |
+          docker save ${{ matrix.tag }} -o image.tar
+          singularity build image.sif docker-archive://image.tar
+
+          echo ${{ secrets.GITHUB_TOKEN }} | singularity remote login -u ${{ github.actor }} --password-stdin oras://ghcr.io
+
+          singularity push image.sif oras://ghcr.io/${{ github.repository_owner }}/${{ matrix.sif }}
+          if [[ "${{ github.event_name }}" == "release" && -n "${{ matrix.extra_tags }}" ]]; then
+            SIF_LATEST=$(echo "${{ matrix.sif }}" | sed 's/:[^:]*$/:latest/')
+            singularity push image.sif oras://ghcr.io/${{ github.repository_owner }}/$SIF_LATEST
+          fi
+
   # ── Sync OpenMS containers (after everything else) ─────────────────────
   sync-openms:
     name: Sync OpenMS Containers
-    needs: [build-diann, build-relink]
+    needs: [build-diann, build-relink, build-wiffconverter]
     if: always() && (github.event_name == 'release' || github.event_name == 'workflow_dispatch') && github.repository_owner == 'bigbio'
     runs-on: ubuntu-latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Please note the following license restrictions:
 - Base Image: `sciex/wiffconverter:0.10`
 - Version: 0.10
 - Architecture: `amd64`/`x86_64`
-- Includes: Mono runtime, `OneOmics.WiffConverter.exe`, `wiff-to-mzml` wrapper
+- Includes: Mono runtime, `OneOmics.WiffConverter.exe`, `convert` wrapper
 
 ## Installation & Usage
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository provides containerized versions of popular proteomics tools:
 - [DIA-NN](https://github.com/vdemichev/DiaNN): A powerful software solution for analyzing DIA proteomics data
 - [Relink](https://github.com/bigbio/relink): Crosslinking mass spectrometry analysis pipeline (xiSEARCH, xiFDR, Scout)
 - [OpenMS](https://www.openms.de/): A versatile open-source software for mass spectrometry data analysis
+- [WiffConverter](https://hub.docker.com/r/sciex/wiffconverter): SCIEX `.wiff` / `.wiff.scan` to indexed `.mzML` conversion via the bundled `OneOmics.WiffConverter` .NET assembly
 
 These containerized versions offer:
 
@@ -85,6 +86,34 @@ docker run -v /path/to/data:/data ghcr.io/bigbio/relink:latest \
   dotnet /opt/scout/Scout_Unix.dll --help
 ```
 
+### WiffConverter Container
+
+The WiffConverter container wraps the upstream [`sciex/wiffconverter`](https://hub.docker.com/r/sciex/wiffconverter) image (bundles Mono + `OneOmics.WiffConverter.exe`) and adds a small `convert` CLI on `PATH`. It is used by [quantmsdiann](https://github.com/bigbio/quantmsdiann) to ingest AbSciex data natively (`.wiff` + companion `.wiff.scan` → indexed `.mzML` in one step, no separate indexing pass). The output is always an `indexedmzML` (the converter is invoked with `--index`).
+
+| Container Type | Tag  | URL                                           |
+| -------------- | ---- | --------------------------------------------- |
+| Docker         | 0.10 | `ghcr.io/bigbio/wiffconverter:0.10`           |
+| Singularity    | 0.10 | `oras://ghcr.io/bigbio/wiffconverter-sif:0.10` |
+
+`0.10` tracks the latest tag published by SCIEX on Docker Hub (2019-05-17).
+
+```bash
+# Convert a SCIEX .wiff (with its .wiff.scan next to it) to indexed mzML:
+docker run --rm -v "$PWD:/data" ghcr.io/bigbio/wiffconverter:0.10 \
+    convert --input /data/sample.wiff --output /data/sample.mzML --mode centroid
+
+# Flags:
+#   --input   SCIEX .wiff file (companion .wiff.scan must sit next to it).
+#   --output  Destination indexed mzML file.
+#   --mode    'centroid' (default) or 'profile'.
+#   --log     Path to keep the converter log (default: only kept on failure).
+```
+
+On failure the wrapper prints a banner with the input/output/mode and the last
+40 lines of the underlying SCIEX converter log, so most issues (missing
+`.wiff.scan`, locked output, unsupported acquisition) are diagnosable from the
+console without re-running.
+
 ### OpenMS Containers
 
 OpenMS containers are publicly available and can be pulled directly:
@@ -105,6 +134,7 @@ Please note the following license restrictions:
 - **DIA-NN**: Custom academic license with restrictions. Please review the [DIA-NN license](diann-2.1.0/LICENSE.txt) before using. No commercial use or cloud deployment without collaboration agreement.
 - **Relink/xiSEARCH/xiFDR/Scout**: Please review the individual tool licenses
 - **OpenMS**: Available under the [BSD 3-Clause License](https://github.com/OpenMS/OpenMS/blob/develop/LICENSE)
+- **WiffConverter**: Proprietary SCIEX redistributable (via the public `sciex/wiffconverter` Docker Hub image). Users are responsible for complying with SCIEX's terms of use.
 
 ## Technical Specifications
 
@@ -127,6 +157,13 @@ Please note the following license restrictions:
 
 - Sourced from: `ghcr.io/openms/openms-tools-thirdparty`
 - Architecture: `amd64`/`x86_64`
+
+### WiffConverter Container
+
+- Base Image: `sciex/wiffconverter:0.10`
+- Version: 0.10
+- Architecture: `amd64`/`x86_64`
+- Includes: Mono runtime, `OneOmics.WiffConverter.exe`, `wiff-to-mzml` wrapper
 
 ## Installation & Usage
 
@@ -231,7 +268,8 @@ This repository includes a GitHub Actions workflow that builds and syncs all con
 
 1. Builds and pushes DIA-NN Docker and Singularity containers (all versions)
 2. Builds and pushes Relink Docker and Singularity containers
-3. Syncs OpenMS containers from the official repository to BigBio
+3. Builds and pushes WiffConverter Docker and Singularity containers
+4. Syncs OpenMS containers from the official repository to BigBio
 
 The workflow is triggered by:
 

--- a/wiffconverter-0.10/Dockerfile
+++ b/wiffconverter-0.10/Dockerfile
@@ -1,0 +1,28 @@
+FROM sciex/wiffconverter:0.10
+
+# Some metadata
+LABEL base_image="sciex/wiffconverter:0.10"
+LABEL version="2"
+LABEL software="wiffconverter"
+LABEL software.version="0.10"
+LABEL about.summary="SCIEX WIFF to indexed mzML converter (bundled OneOmics.WiffConverter + Mono)."
+LABEL about.home="https://hub.docker.com/r/sciex/wiffconverter"
+LABEL about.documentation="https://sciex.com/products/software/"
+LABEL about.license="Proprietary (SCIEX)"
+LABEL about.tags="Proteomics,AbSciex,WIFF,MassSpectrometry"
+LABEL maintainer="Yasset Perez-Riverol <ypriverol@gmail.com>"
+
+# Sanity check: upstream image must ship mono and the WiffConverter .NET assembly.
+RUN test -x /usr/bin/mono && \
+    test -f /usr/local/bin/sciex/wiffconverter/OneOmics.WiffConverter.exe
+
+# Install the `convert` CLI on PATH.
+COPY convert /usr/local/bin/convert
+RUN chmod +x /usr/local/bin/convert
+
+# Reset ENTRYPOINT/CMD so the container behaves like a normal shell image
+# (matches the DIA-NN / Relink / OpenMS containers in this repo).
+ENTRYPOINT []
+CMD ["/bin/bash"]
+
+WORKDIR /data/

--- a/wiffconverter-0.10/convert
+++ b/wiffconverter-0.10/convert
@@ -1,0 +1,126 @@
+#!/bin/bash
+# convert: SCIEX .wiff (+ companion .wiff.scan) → indexed mzML.
+#
+# Usage:
+#   convert --input <file.wiff> --output <file.mzML> [--mode centroid|profile] [--log <file>]
+#
+# The output is always an indexedmzML (SCIEX --index): downstream tools in the
+# quantms stack require <indexList> for random access.
+
+set -euo pipefail
+
+WIFF_BIN="/usr/local/bin/sciex/wiffconverter/OneOmics.WiffConverter.exe"
+
+INPUT=""
+OUTPUT=""
+MODE="centroid"
+LOG=""
+
+usage() {
+    cat <<EOF >&2
+Usage: $(basename "$0") --input <file.wiff> --output <file.mzML> [--mode centroid|profile] [--log <file>]
+
+Required:
+  --input   SCIEX .wiff file (companion .wiff.scan must sit next to it).
+  --output  Destination indexed mzML file.
+
+Optional:
+  --mode    Peak picking mode: 'centroid' (default) or 'profile'.
+  --log     Write the underlying converter log to this path. If omitted, the
+            log is written to <output>.log and only kept on failure.
+  -h, --help  Show this help and exit.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --input)  INPUT="${2:-}"; shift 2 ;;
+        --output) OUTPUT="${2:-}"; shift 2 ;;
+        --mode)   MODE="${2:-}"; shift 2 ;;
+        --log)    LOG="${2:-}"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "convert: unknown argument '$1'" >&2; usage; exit 64 ;;
+    esac
+done
+
+if [[ -z "$INPUT" || -z "$OUTPUT" ]]; then
+    echo "convert: --input and --output are required" >&2
+    usage
+    exit 64
+fi
+
+case "$MODE" in
+    centroid|profile) ;;
+    *)
+        echo "convert: invalid --mode '$MODE' (expected 'centroid' or 'profile')" >&2
+        exit 64
+        ;;
+esac
+
+if [[ ! -f "$INPUT" ]]; then
+    echo "convert: input '$INPUT' not found" >&2
+    exit 66
+fi
+if [[ ! -f "${INPUT}.scan" ]]; then
+    echo "convert: companion scan '${INPUT}.scan' not found next to input" >&2
+    exit 66
+fi
+
+KEEP_LOG=1
+if [[ -z "$LOG" ]]; then
+    LOG="${OUTPUT}.log"
+    KEEP_LOG=0  # only retain on failure
+fi
+
+# Make sure mono's stdout/stderr is captured to the log; tee it for live progress.
+status=0
+/usr/bin/mono "$WIFF_BIN" \
+    WIFF "$INPUT" "-$MODE" \
+    MZML "$OUTPUT" \
+    --singleprecision --nocompression --index --overwrite \
+    > >(tee "$LOG") 2>&1 || status=$?
+
+fail() {
+    local msg="$1"
+    echo "" >&2
+    echo "================================================================" >&2
+    echo " convert FAILED: $msg" >&2
+    echo "  input : $INPUT" >&2
+    echo "  output: $OUTPUT" >&2
+    echo "  mode  : $MODE" >&2
+    echo "  log   : $LOG" >&2
+    echo "----------------------------------------------------------------" >&2
+    echo " Last 40 lines of converter log:" >&2
+    echo "----------------------------------------------------------------" >&2
+    tail -n 40 "$LOG" >&2 || true
+    echo "================================================================" >&2
+    exit 2
+}
+
+if [[ $status -ne 0 ]]; then
+    fail "OneOmics.WiffConverter exited with status $status"
+fi
+
+if [[ ! -s "$OUTPUT" ]]; then
+    fail "output '$OUTPUT' was not written or is empty"
+fi
+
+# OneOmics.WiffConverter does not always propagate failure via its exit code,
+# so verify the output is a well-formed indexedmzML.
+end=$(tail -n 1 "$OUTPUT")
+if [[ "$end" != "</indexedmzML>" ]]; then
+    fail "output is not a well-formed indexedmzML (last line: $end)"
+fi
+
+# Sanity-check the index actually exists in the file.
+if ! grep -q "<indexList " "$OUTPUT"; then
+    fail "output is missing <indexList> element"
+fi
+
+# Success — drop the log unless the user asked to keep it.
+if [[ "$KEEP_LOG" -eq 0 ]]; then
+    rm -f "$LOG"
+fi
+
+bytes=$(stat -c %s "$OUTPUT")
+echo "convert: success  output=$OUTPUT  size=${bytes}B  mode=$MODE  indexed=yes"

--- a/wiffconverter-0.10/convert
+++ b/wiffconverter-0.10/convert
@@ -72,13 +72,18 @@ if [[ -z "$LOG" ]]; then
     KEEP_LOG=0  # only retain on failure
 fi
 
-# Make sure mono's stdout/stderr is captured to the log; tee it for live progress.
+# Capture mono's stdout/stderr to the log and tee it for live progress.
+# Use a real pipe (not >(tee ...)) so the script waits for tee to flush before
+# we read $LOG in fail() or remove it on success.
 status=0
+set +e
 /usr/bin/mono "$WIFF_BIN" \
     WIFF "$INPUT" "-$MODE" \
     MZML "$OUTPUT" \
     --singleprecision --nocompression --index --overwrite \
-    > >(tee "$LOG") 2>&1 || status=$?
+    2>&1 | tee "$LOG"
+status=${PIPESTATUS[0]}
+set -e
 
 fail() {
     local msg="$1"


### PR DESCRIPTION
## Summary

- New `wiffconverter-0.10/` container wraps `sciex/wiffconverter:0.10` and adds a `convert` CLI on `PATH` for SCIEX `.wiff` → indexed mzML in one step.
- Always emits `indexedmzML` (`--index` is hard-wired); on failure prints a framed banner with the last 40 lines of the converter log and retains `<output>.log` for diagnosis.
- CLI style matches the DIA-NN / Relink sister containers: `convert --input X --output Y --mode centroid|profile`.
- README updated with usage + always-`--index` guarantee + failure-banner behavior.

## Why a wrapper

- `OneOmics.WiffConverter.exe` does not always propagate failure via exit code → wrapper validates the output ends `</indexedmzML>` and has an `<indexList>` before reporting success.
- Downstream tools (DIA-NN, OpenMS) require a valid `<indexList>` for random access, so non-indexed output is always a bug here.
- Friendly errors so most issues (missing `.wiff.scan`, locked output, unsupported acquisition) are diagnosable from the console without re-running.

## Validation

Tested against [PXD073289](https://ftp.pride.ebi.ac.uk/pride/data/archive/2026/03/PXD073289/) (`OA_5.wiff` + 936 MB `.wiff.scan`):

- Success path: 1.4 GB output, 192,076 spectra, ends `</indexedmzML>`, has `<indexList>`, success banner printed, log auto-deleted. Result deterministic across two independent runs.
- Pre-flight error (missing input / no companion `.wiff.scan`): one-line message, exit 64/66.
- Mono failure (corrupt `.wiff`): framed banner + last 40 lines of `OpenMcdf.CFFileFormatException` traceback, log retained at `<output>.log`, exit 2.

## CI follow-up (separate commit needed)

This branch deliberately omits the `build-wiffconverter` job in `.github/workflows/quantms-containers.yml` — the token used to push this branch lacks `workflow` scope. The diff is ready locally and will be applied in a follow-up commit so a maintainer with `workflow` permissions can land it.

## Test plan
- [ ] CI green (Dockerfile builds with `docker build -t ghcr.io/bigbio/wiffconverter:0.10 wiffconverter-0.10/`)
- [ ] Smoke test on a SCIEX `.wiff` → confirm `convert: success ... indexed=yes` and `</indexedmzML>` tail
- [ ] Smoke test failure path → confirm banner + retained log
- [ ] Apply the workflow CI job in a follow-up commit (needs `workflow` scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added WiffConverter docs, usage for Docker/Singularity, container metadata, and updated license terms for SCIEX redistributable.

* **New Features**
  * Ship a containerized WiffConverter with a user-facing convert command that produces indexed .mzML (default centroid mode), optional logging, and concise success output.

* **Bug Fixes / Reliability**
  * Improved failure reporting with a clear banner and tail of recent log lines for easier troubleshooting.

* **Chores**
  * Adjusted CI/CD ordering to build/push WiffConverter before syncing other containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->