### PR TITLE
fix: avoid tee race in convert and correct README wrapper name

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Please note the following license restrictions:
 - Base Image: `sciex/wiffconverter:0.10`
 - Version: 0.10
 - Architecture: `amd64`/`x86_64`
-- Includes: Mono runtime, `OneOmics.WiffConverter.exe`, `wiff-to-mzml` wrapper
+- Includes: Mono runtime, `OneOmics.WiffConverter.exe`, `convert` wrapper
 
 ## Installation & Usage
 

--- a/wiffconverter-0.10/convert
+++ b/wiffconverter-0.10/convert
@@ -72,13 +72,18 @@ if [[ -z "$LOG" ]]; then
     KEEP_LOG=0  # only retain on failure
 fi
 
-# Make sure mono's stdout/stderr is captured to the log; tee it for live progress.
+# Capture mono's stdout/stderr to the log and tee it for live progress.
+# Use a real pipe (not >(tee ...)) so the script waits for tee to flush before
+# we read $LOG in fail() or remove it on success.
 status=0
+set +e
 /usr/bin/mono "$WIFF_BIN" \
     WIFF "$INPUT" "-$MODE" \
     MZML "$OUTPUT" \
     --singleprecision --nocompression --index --overwrite \
-    > >(tee "$LOG") 2>&1 || status=$?
+    2>&1 | tee "$LOG"
+status=${PIPESTATUS[0]}
+set -e
 
 fail() {
     local msg="$1"


### PR DESCRIPTION
- convert: replace `> >(tee ...)` process substitution with a regular pipe + PIPESTATUS so the script waits for tee to flush before fail() tails the log or success removes it (no orphan logs, no truncated failure banners).
- README: the WiffConverter container ships a `convert` wrapper, not `wiff-to-mzml`.